### PR TITLE
fix(macos): preserve managed SSH keys read from Keychain

### DIFF
--- a/crates/oxideterm-ai/src/key_store.rs
+++ b/crates/oxideterm-ai/src/key_store.rs
@@ -208,7 +208,7 @@ impl AiProviderKeyStore {
         provider_id: &str,
     ) -> Result<Option<Zeroizing<String>>> {
         NativeSecretStore::new(&self.service)
-            .get_and_relax(&self.account(provider_id))
+            .get(&self.account(provider_id))
             .with_context(|| format!("failed to load AI provider key for {provider_id}"))
     }
 

--- a/crates/oxideterm-cloud-sync/src/secrets.rs
+++ b/crates/oxideterm-cloud-sync/src/secrets.rs
@@ -156,7 +156,7 @@ impl CloudSyncKeychainSecretProvider {
         }
 
         NativeSecretStore::new(&self.service)
-            .get_and_relax(&account)
+            .get(&account)
             .map_err(|error| CloudSyncSecretError::AccessFailed(error.to_string()))
     }
 
@@ -165,7 +165,7 @@ impl CloudSyncKeychainSecretProvider {
         key: &str,
     ) -> Result<Option<CloudSyncSecretValue>, CloudSyncSecretError> {
         NativeSecretStore::new(&self.legacy_service)
-            .get_and_relax(&self.legacy_account(key))
+            .get(&self.legacy_account(key))
             .map_err(|error| CloudSyncSecretError::AccessFailed(error.to_string()))
     }
 

--- a/crates/oxideterm-connections/src/keychain.rs
+++ b/crates/oxideterm-connections/src/keychain.rs
@@ -181,7 +181,7 @@ impl ConnectionKeychain {
         }
 
         NativeSecretStore::new(&self.service)
-            .get_and_relax(&self.native_account(id))
+            .get(&self.native_account(id))
             // Move the keychain result directly into its zeroizing domain owner
             // so no unmanaged String copy survives this boundary.
             .map(|secret| secret.map(SecretString::from))

--- a/crates/oxideterm-connections/src/store/connection_store.rs
+++ b/crates/oxideterm-connections/src/store/connection_store.rs
@@ -2454,17 +2454,30 @@ impl ConnectionStore {
     }
 
     pub fn resolve_managed_ssh_key_private_key(&self, id: &str) -> Result<SecretString> {
-        let secret_id = self
+        let managed_key = self
             .data
             .managed_ssh_keys
             .iter()
             .find(|key| key.id == id)
-            .map(|key| key.secret_id.clone())
             .ok_or_else(|| anyhow::anyhow!("Managed SSH key not found"))?;
+        let private_key = self.get_managed_ssh_key_secret(&managed_key.secret_id)?;
+        let Some(recovery) = recover_legacy_hex_managed_private_key(
+            &private_key,
+            &managed_key.fingerprint,
+            managed_key.requires_passphrase,
+        )? else {
+            // Secret material leaves the managed backend only at the SSH auth boundary.
+            // Callers must decode/use it immediately and must not persist this value.
+            return Ok(private_key);
+        };
 
-        // Secret material leaves the managed backend only at the SSH auth boundary.
-        // Callers must decode/use it immediately and must not persist this value.
-        self.get_managed_ssh_key_secret(&secret_id)
+        if recovery.safe_to_persist {
+            // Older macOS builds could rewrite a multiline Keychain value as hexadecimal text.
+            // Persist only fingerprint-validated recovery so later reads use the original bytes.
+            self.store_managed_ssh_key_secret(&managed_key.secret_id, &recovery.private_key)
+                .context("failed to repair a legacy managed SSH key")?;
+        }
+        Ok(recovery.private_key)
     }
 
     fn create_managed_ssh_key(

--- a/crates/oxideterm-connections/src/store/helpers.rs
+++ b/crates/oxideterm-connections/src/store/helpers.rs
@@ -138,6 +138,99 @@ fn managed_key_display_name(name: Option<String>, fallback: &str) -> String {
         .to_string()
 }
 
+struct LegacyManagedPrivateKeyRecovery {
+    private_key: SecretString,
+    safe_to_persist: bool,
+}
+
+fn recover_legacy_hex_managed_private_key(
+    private_key: &SecretString,
+    expected_fingerprint: &str,
+    requires_passphrase: bool,
+) -> Result<Option<LegacyManagedPrivateKeyRecovery>> {
+    if has_supported_private_key_container(private_key.expose_secret()) {
+        return Ok(None);
+    }
+
+    let Some(recovered) = decode_ascii_hex_secret(private_key.expose_secret()) else {
+        return Ok(None);
+    };
+    if !has_supported_private_key_container(recovered.expose_secret()) {
+        return Ok(None);
+    }
+    let safe_to_persist = if requires_passphrase {
+        // The encrypted key cannot be fingerprint-validated until the caller supplies its
+        // passphrase. Return the recovered value for authentication, but leave Keychain
+        // unchanged rather than persisting unverified material.
+        false
+    } else {
+        let decoded_key = decode_managed_private_key(&recovered, None)?;
+        if fingerprint_public_key(decoded_key.public_key()) != expected_fingerprint {
+            bail!("Managed SSH key integrity check failed");
+        }
+        true
+    };
+    Ok(Some(LegacyManagedPrivateKeyRecovery {
+        private_key: recovered,
+        safe_to_persist,
+    }))
+}
+
+fn has_supported_private_key_container(private_key: &str) -> bool {
+    let private_key = private_key.trim();
+    if private_key.starts_with("PuTTY-User-Key-File-") {
+        return private_key.lines().any(|line| line.starts_with("Private-Lines:"))
+            && private_key.lines().any(|line| line.starts_with("Private-MAC:"));
+    }
+
+    [
+        (
+            "-----BEGIN OPENSSH PRIVATE KEY-----",
+            "-----END OPENSSH PRIVATE KEY-----",
+        ),
+        (
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "-----END RSA PRIVATE KEY-----",
+        ),
+        (
+            "-----BEGIN ENCRYPTED PRIVATE KEY-----",
+            "-----END ENCRYPTED PRIVATE KEY-----",
+        ),
+        ("-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"),
+        (
+            "-----BEGIN EC PRIVATE KEY-----",
+            "-----END EC PRIVATE KEY-----",
+        ),
+    ]
+    .iter()
+    .any(|(begin, end)| private_key.starts_with(begin) && private_key.ends_with(end))
+}
+
+fn decode_ascii_hex_secret(secret: &str) -> Option<SecretString> {
+    let encoded = secret.as_bytes();
+    if encoded.is_empty() || encoded.len() % 2 != 0 {
+        return None;
+    }
+
+    let mut decoded = zeroize::Zeroizing::new(Vec::with_capacity(encoded.len() / 2));
+    for pair in encoded.chunks_exact(2) {
+        let high = decode_ascii_hex_digit(pair[0])?;
+        let low = decode_ascii_hex_digit(pair[1])?;
+        decoded.push((high << 4) | low);
+    }
+    let decoded = std::str::from_utf8(decoded.as_slice()).ok()?;
+    Some(SecretString::from(decoded.to_owned()))
+}
+
+fn decode_ascii_hex_digit(digit: u8) -> Option<u8> {
+    match digit {
+        b'0'..=b'9' => Some(digit - b'0'),
+        b'a'..=b'f' => Some(digit - b'a' + 10),
+        b'A'..=b'F' => Some(digit - b'A' + 10),
+        _ => None,
+    }
+}
+
 fn decode_managed_private_key(
     private_key: &SecretString,
     passphrase: Option<&SecretString>,

--- a/crates/oxideterm-connections/src/store/tests.rs
+++ b/crates/oxideterm-connections/src/store/tests.rs
@@ -2723,6 +2723,111 @@ mod tests {
     }
 
     #[test]
+    fn managed_key_resolve_repairs_legacy_hex_encoded_secret() {
+        let mut store = load_empty_store("managed-key-legacy-hex");
+        let private_key = generated_private_key_text(None);
+        let info = store
+            .create_managed_ssh_key_from_text(
+                SecretString::from(private_key.clone()),
+                Some("Legacy Keychain Key".to_string()),
+                None,
+            )
+            .unwrap();
+        let secret_id = store.data.managed_ssh_keys[0].secret_id.clone();
+        let legacy_hex = private_key
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        store
+            .managed_keychain
+            .store(&secret_id, &SecretString::from(legacy_hex))
+            .unwrap();
+
+        let restored = store
+            .resolve_managed_ssh_key_private_key(&info.id)
+            .expect("legacy hexadecimal managed key should be repaired");
+
+        assert_eq!(restored, private_key.as_str());
+        assert_eq!(
+            store.managed_keychain.get(&secret_id).unwrap(),
+            private_key.as_str(),
+            "the repaired private key should replace the legacy hexadecimal value"
+        );
+    }
+
+    #[test]
+    fn managed_key_resolve_does_not_persist_unverified_encrypted_recovery() {
+        let mut store = load_empty_store("managed-key-encrypted-legacy-hex");
+        let passphrase = SecretString::from("secret-passphrase");
+        let private_key = generated_private_key_text(Some(passphrase.expose_secret()));
+        let info = store
+            .create_managed_ssh_key_from_text(
+                SecretString::from(private_key.clone()),
+                Some("Encrypted Legacy Keychain Key".to_string()),
+                Some(passphrase.clone()),
+            )
+            .unwrap();
+        let secret_id = store.data.managed_ssh_keys[0].secret_id.clone();
+        let legacy_hex = private_key
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        store
+            .managed_keychain
+            .store(&secret_id, &SecretString::from(legacy_hex.clone()))
+            .unwrap();
+
+        let restored = store
+            .resolve_managed_ssh_key_private_key(&info.id)
+            .expect("encrypted legacy hexadecimal key should be usable for authentication");
+
+        assert_eq!(restored, private_key.as_str());
+        decode_managed_private_key(&restored, Some(&passphrase))
+            .expect("the caller-provided passphrase should validate the recovered key");
+        assert_eq!(
+            store.managed_keychain.get(&secret_id).unwrap(),
+            legacy_hex.as_str(),
+            "encrypted recovery must not be persisted before fingerprint validation"
+        );
+    }
+
+    #[test]
+    fn managed_key_resolve_rejects_legacy_hex_with_wrong_fingerprint() {
+        let mut store = load_empty_store("managed-key-legacy-hex-mismatch");
+        let expected_key = generated_private_key_text(None);
+        let different_key = generated_private_key_text(None);
+        let info = store
+            .create_managed_ssh_key_from_text(
+                SecretString::from(expected_key),
+                Some("Expected Key".to_string()),
+                None,
+            )
+            .unwrap();
+        let secret_id = store.data.managed_ssh_keys[0].secret_id.clone();
+        let legacy_hex = different_key
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        store
+            .managed_keychain
+            .store(&secret_id, &SecretString::from(legacy_hex.clone()))
+            .unwrap();
+
+        let error = store
+            .resolve_managed_ssh_key_private_key(&info.id)
+            .expect_err("a different legacy key must fail its metadata integrity check");
+
+        assert_eq!(error.to_string(), "Managed SSH key integrity check failed");
+        assert_eq!(
+            store.managed_keychain.get(&secret_id).unwrap(),
+            legacy_hex.as_str()
+        );
+    }
+
+    #[test]
     fn managed_key_secret_file_round_trips_large_private_key_material() {
         let data_dir =
             std::env::temp_dir().join(format!("oxideterm-managed-key-secret-{}", Uuid::new_v4()));

--- a/crates/oxideterm-secret-store/src/lib.rs
+++ b/crates/oxideterm-secret-store/src/lib.rs
@@ -75,18 +75,6 @@ impl NativeSecretStore {
         }
     }
 
-    /// Loads a secret and restores the Preview 14 ACL after a successful read.
-    pub fn get_and_relax(&self, account: &str) -> Result<Option<Zeroizing<String>>> {
-        let secret = self.get(account)?;
-        #[cfg(target_os = "macos")]
-        if let Some(secret) = secret.as_ref() {
-            // Callers use this only after accepting the stored value as a valid
-            // domain secret, so invalid config keys take the plain get path.
-            self.store(account, secret.as_str())?;
-        }
-        Ok(secret)
-    }
-
     pub fn delete(&self, account: &str) -> Result<()> {
         #[cfg(target_os = "macos")]
         {

--- a/crates/oxideterm-secret-store/src/macos.rs
+++ b/crates/oxideterm-secret-store/src/macos.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use keyring::{Entry, Error as KeyringError};
 use std::process::Command;
 use zeroize::Zeroizing;
 
@@ -60,24 +61,14 @@ pub(super) fn exists(service: &str, account: &str) -> Result<bool> {
 }
 
 fn read_password(service: &str, account: &str) -> Result<Option<Zeroizing<String>>> {
-    let output = Command::new(SECURITY_TOOL_PATH)
-        .args(["find-generic-password", "-s", service, "-a", account, "-w"])
-        .output()
-        .context("failed to run the macOS keychain tool to load a secret")?;
-    if output.status.success() {
-        // The command output owns secret bytes, so zeroize that allocation after
-        // moving the decoded value into its domain owner.
-        let output = Zeroizing::new(output.stdout);
-        let secret = std::str::from_utf8(output.as_slice())
-            .context("macOS keychain secret is not valid UTF-8")?;
-        return Ok(Some(Zeroizing::new(
-            secret.trim_end_matches(['\r', '\n']).to_owned(),
-        )));
-    }
-    if output.status.code() == Some(SECURITY_ITEM_NOT_FOUND_EXIT_CODE) {
-        Ok(None)
-    } else {
-        anyhow::bail!("failed to load a secret from the macOS keychain")
+    // The security CLI renders multiline generic-password data as hexadecimal on
+    // newer macOS releases, while the native Keychain backend returns the bytes intact.
+    let entry = Entry::new(service, account)
+        .context("failed to open a macOS keychain entry for secret loading")?;
+    match entry.get_password() {
+        Ok(secret) => Ok(Some(Zeroizing::new(secret))),
+        Err(KeyringError::NoEntry) => Ok(None),
+        Err(error) => Err(error).context("failed to load a secret from the macOS keychain"),
     }
 }
 

--- a/crates/oxideterm-secret-store/src/macos.rs
+++ b/crates/oxideterm-secret-store/src/macos.rs
@@ -63,6 +63,8 @@ pub(super) fn exists(service: &str, account: &str) -> Result<bool> {
 fn read_password(service: &str, account: &str) -> Result<Option<Zeroizing<String>>> {
     // The security CLI renders multiline generic-password data as hexadecimal on
     // newer macOS releases, while the native Keychain backend returns the bytes intact.
+    // Keep reads non-mutating: recreating the item through the CLI would replace any
+    // persisted application approval with the CLI's `apple-tool:` ACL partition.
     let entry = Entry::new(service, account)
         .context("failed to open a macOS keychain entry for secret loading")?;
     match entry.get_password() {

--- a/crates/oxideterm-secret-store/tests/macos_keychain.rs
+++ b/crates/oxideterm-secret-store/tests/macos_keychain.rs
@@ -8,10 +8,34 @@ use oxideterm_secret_store::NativeSecretStore;
 
 #[test]
 #[ignore = "touches the current user's macOS keychain"]
+fn real_keychain_round_trip_preserves_multiline_secret() {
+    let store = NativeSecretStore::new(format!(
+        "com.oxideterm.test.multiline.{}",
+        std::process::id()
+    ));
+    let account = "native-secret-store-multiline-round-trip";
+    let secret = "-----BEGIN SYNTHETIC PRIVATE KEY-----\nline1\nline2\n-----END SYNTHETIC PRIVATE KEY-----\n";
+
+    let result = (|| -> Result<()> {
+        store.store(account, secret)?;
+        ensure!(
+            store.get(account)?.as_ref().map(|value| value.as_str()) == Some(secret),
+            "stored multiline keychain secret must round-trip"
+        );
+        Ok(())
+    })();
+    let cleanup = store.delete(account);
+
+    result.expect("real multiline keychain round-trip succeeds");
+    cleanup.expect("real multiline keychain test entry is removed");
+}
+
+#[test]
+#[ignore = "touches the current user's macOS keychain"]
 fn real_keychain_round_trip_uses_preview_14_access() {
     let store = NativeSecretStore::new(format!("com.oxideterm.test.{}", std::process::id()));
     let account = "native-secret-store-round-trip";
-    let secret = "synthetic-test-secret";
+    let secret = "deadbeef0123";
 
     // Cleanup runs even when the round-trip assertion reports an error.
     let result = (|| -> Result<()> {


### PR DESCRIPTION
Fixes #485

## Summary

- read macOS Keychain secrets through the native Apple backend so multiline values round-trip unchanged
- preserve the existing CLI-based `add-generic-password -A` write behavior
- keep native reads non-mutating so macOS can retain the user-approved application ACL
- recover managed SSH private keys that were previously persisted as hexadecimal text
- persist recovered unencrypted keys only after their public-key fingerprint matches stored metadata
- return encrypted recovery for authentication without rewriting Keychain before passphrase-based validation is possible

## Root cause

On affected macOS builds, `/usr/bin/security find-generic-password -w` can render multiline generic-password data as unprefixed hexadecimal text. The previous read path treated that representation as the secret, and `get_and_relax` could write it back. The SSH parser then received hexadecimal text instead of an OpenSSH, PEM, or PuTTY private-key container and reported `unsupported ssh private key format`.

After switching reads to the native backend, the former read-time rewrite also caused repeated authorization prompts: each successful application read was followed by deleting and recreating the item through `/usr/bin/security`, replacing the application approval with the CLI's `apple-tool:` ACL partition. Reads are now non-mutating so an approval can persist for the current application identity.

## Implementation

`oxideterm-secret-store` now uses `keyring::Entry::get_password()` for reads on macOS. Writes continue to use the current `security add-generic-password ... -A` path so the existing development-build ACL behavior is retained.

For entries already affected, recovery is deliberately limited to the managed SSH private-key boundary. It requires valid even-length ASCII hexadecimal text whose decoded UTF-8 value has a supported private-key container. Unencrypted recovery must also match the managed key's stored public-key fingerprint before the corrected value is persisted. Ordinary passwords and legitimate hexadecimal single-line secrets do not enter this recovery path.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p oxideterm-secret-store --lib` — 2 passed
- `cargo test -p oxideterm-secret-store --test macos_keychain -- --ignored --test-threads=1 --nocapture` — 2 passed against the real macOS Keychain
- `cargo test -p oxideterm-connections --lib` — 161 passed
- `cargo test -p oxideterm-ai --lib` — 193 passed
- `cargo test -p oxideterm-cloud-sync --lib` — 77 passed
- `cargo check -p oxideterm-secret-store`
- `cargo check -p oxideterm-connections`
- reproduced affected managed-key data was recovered to the original multiline value and accepted by the SSH private-key parser
- `cargo build --workspace -p oxideterm-gpui-app --bin oxideterm-native --release --features gpui_platform/runtime_shaders` on Apple Silicon macOS
- manual macOS verification (2026-08-30): after installing the patched ad-hoc-signed build, the first managed-key access prompted once for the new application identity; after choosing **Always Allow**, repeated SSH connections with the same managed key succeeded without another macOS password prompt

