### PR TITLE
fix(terminal): 时间戳改用稳定的回滚行号作为键

### DIFF
--- a/crates/oxideterm-gpui-terminal/src/app.rs
+++ b/crates/oxideterm-gpui-terminal/src/app.rs
@@ -1248,11 +1248,15 @@ impl TerminalPane {
     }
 
     fn trim_row_timestamps(&mut self, snapshot: &TerminalSnapshot) {
-        let Some(max_line) = snapshot.lines.iter().map(|row| row.line_id).max() else {
+        if snapshot.lines.is_empty() {
             Arc::make_mut(&mut self.row_timestamps).clear();
             self.row_timestamp_retained_min_line = None;
             return;
-        };
+        }
+        let max_line = snapshot
+            .scrollback_lines
+            .saturating_add(snapshot.rows)
+            .saturating_add(1) as u64;
         let retained_rows = self
             .preferences
             .scrollback_lines
@@ -3800,10 +3804,13 @@ fn record_timestampable_snapshot_rows(
     label: &str,
 ) {
     for row in &snapshot.lines {
+        let Some(line_number) = terminal_line_number(snapshot, row) else {
+            continue;
+        };
         // The snapshot signature is a cheap invalidation key. Cursor-only changes
         // still fall through to the content signature comparison below.
         if row_timestamps
-            .get(&row.line_id)
+            .get(&line_number)
             .is_some_and(|timestamp| timestamp.source_signature == row.signature)
         {
             continue;
@@ -3811,7 +3818,7 @@ fn record_timestampable_snapshot_rows(
 
         if terminal_row_has_timestamp_content(row) {
             let timestamp_signature = terminal_row_timestamp_signature(row);
-            if let Some(timestamp) = row_timestamps.get_mut(&row.line_id) {
+            if let Some(timestamp) = row_timestamps.get_mut(&line_number) {
                 if timestamp.signature != timestamp_signature {
                     timestamp.label = label.to_string();
                     timestamp.signature = timestamp_signature;
@@ -3819,7 +3826,7 @@ fn record_timestampable_snapshot_rows(
                 timestamp.source_signature = row.signature;
             } else {
                 row_timestamps.insert(
-                    row.line_id,
+                    line_number,
                     TerminalRowTimestamp {
                         label: label.to_string(),
                         signature: timestamp_signature,
@@ -3830,7 +3837,7 @@ fn record_timestampable_snapshot_rows(
         } else {
             // Blank viewport rows are recycled later. Removing their metadata
             // prevents new output from inheriting a stale line-modification time.
-            row_timestamps.remove(&row.line_id);
+            row_timestamps.remove(&line_number);
         }
     }
 }
@@ -4318,14 +4325,15 @@ mod tests {
         let blank_snapshot = timestamp_test_snapshot(timestamp_test_row(42, "   "));
         record_timestampable_snapshot_rows(&mut row_timestamps, &blank_snapshot, "10:00:00");
 
-        assert!(!row_timestamps.contains_key(&42));
+        // Stable key: scrollback(0) + absolute_line(42) + 1.
+        assert!(!row_timestamps.contains_key(&43));
 
         let content_snapshot = timestamp_test_snapshot(timestamp_test_row(42, "ls"));
         record_timestampable_snapshot_rows(&mut row_timestamps, &content_snapshot, "10:00:01");
 
         assert_eq!(
             row_timestamps
-                .get(&42)
+                .get(&43)
                 .map(|timestamp| timestamp.label.as_str()),
             Some("10:00:01")
         );
@@ -4333,7 +4341,7 @@ mod tests {
         let unchanged_snapshot =
             timestamp_test_snapshot(timestamp_test_row_with_cursor(42, "ls", Some(1), true));
         record_timestampable_snapshot_rows(&mut row_timestamps, &unchanged_snapshot, "10:00:02");
-        let unchanged_timestamp = row_timestamps.get(&42).expect("timestamped row");
+        let unchanged_timestamp = row_timestamps.get(&43).expect("timestamped row");
         assert_eq!(unchanged_timestamp.label, "10:00:01");
         assert_eq!(
             unchanged_timestamp.source_signature,
@@ -4344,7 +4352,7 @@ mod tests {
         record_timestampable_snapshot_rows(&mut row_timestamps, &changed_snapshot, "10:00:03");
         assert_eq!(
             row_timestamps
-                .get(&42)
+                .get(&43)
                 .map(|timestamp| timestamp.label.as_str()),
             Some("10:00:03")
         );
@@ -4356,7 +4364,38 @@ mod tests {
         let cleared_snapshot = timestamp_test_snapshot(timestamp_test_row(42, ""));
         record_timestampable_snapshot_rows(&mut row_timestamps, &cleared_snapshot, "10:00:04");
 
-        assert!(!row_timestamps.contains_key(&42));
+        assert!(!row_timestamps.contains_key(&43));
+    }
+
+    #[test]
+    fn row_timestamps_keep_the_same_key_across_scrollback_growth() {
+        let mut row_timestamps = HashMap::new();
+
+        // The content row sits on the screen with one scrollback line, so its
+        // stable key is scrollback(1) + absolute_line(0) + 1 = 2.
+        let mut first_snapshot = timestamp_test_snapshot(timestamp_test_row(0, "ls"));
+        first_snapshot.scrollback_lines = 1;
+        record_timestampable_snapshot_rows(&mut row_timestamps, &first_snapshot, "10:00:01");
+        assert_eq!(
+            row_timestamps
+                .get(&2)
+                .map(|timestamp| timestamp.label.as_str()),
+            Some("10:00:01")
+        );
+
+        // New output pushes the same content into scrollback: scrollback grows
+        // by one while absolute_line drops by one, so the key must stay 2 and
+        // the label must not be re-stamped.
+        let mut second_snapshot = timestamp_test_snapshot(timestamp_test_row(-1, "ls"));
+        second_snapshot.scrollback_lines = 2;
+        record_timestampable_snapshot_rows(&mut row_timestamps, &second_snapshot, "10:00:02");
+        assert_eq!(
+            row_timestamps
+                .get(&2)
+                .map(|timestamp| timestamp.label.as_str()),
+            Some("10:00:01"),
+            "scrolling must not re-stamp the same content line"
+        );
     }
 
     #[test]

--- a/crates/oxideterm-gpui-terminal/src/terminal_ui.rs
+++ b/crates/oxideterm-gpui-terminal/src/terminal_ui.rs
@@ -9,7 +9,8 @@ use oxideterm_settings::{
     TerminalBackspaceSequence, TerminalDeleteSequence, TerminalSemanticScheme,
 };
 use oxideterm_terminal::{
-    TerminalColor, TerminalCursorShape, TerminalEncoding, TrzszTransferPolicy,
+    TerminalColor, TerminalCursorShape, TerminalEncoding, TerminalRow, TerminalSnapshot,
+    TrzszTransferPolicy,
 };
 use oxideterm_terminal_semantic::{
     CompiledSemanticScheme, SemanticClass, SemanticScheme, SemanticSchemeDocument,
@@ -1021,6 +1022,14 @@ pub(crate) fn terminal_timestamp_gutter_width(metrics: &TerminalMetrics, enabled
     } else {
         0.0
     }
+}
+
+/// Stable session line number for one snapshot row. `scrollback_lines +
+/// absolute_line + 1` stays constant for the same content across scrolling and
+/// new output, unlike `line_id`, which snapshots reassign while scrolling.
+pub(crate) fn terminal_line_number(snapshot: &TerminalSnapshot, row: &TerminalRow) -> Option<u64> {
+    let number = snapshot.scrollback_lines as i64 + row.absolute_line + 1;
+    (number >= 1).then_some(number as u64)
 }
 
 pub(crate) fn fallback_cell_width(window: &mut Window, font: &Font, font_size: Pixels) -> Pixels {

--- a/crates/oxideterm-gpui-terminal/src/terminal_view/element.rs
+++ b/crates/oxideterm-gpui-terminal/src/terminal_view/element.rs
@@ -863,7 +863,9 @@ impl TerminalElement {
                     &mut cursor,
                 );
             }
-            if let Some(timestamp_run) = self.timestamp_run_for_row(row_index, row.line_id) {
+            if let Some(timestamp_run) = terminal_line_number(&self.snapshot, row)
+                .and_then(|line_number| self.timestamp_run_for_row(row_index, line_number))
+            {
                 timestamp_runs.push(timestamp_run);
             }
         }
@@ -917,8 +919,13 @@ impl TerminalElement {
         }
     }
 
-    fn timestamp_run_for_row(&self, row_index: usize, line_id: u64) -> Option<BatchedTextRun> {
-        let label = self.row_timestamps.as_ref()?.get(&line_id)?.label.clone();
+    fn timestamp_run_for_row(&self, row_index: usize, line_number: u64) -> Option<BatchedTextRun> {
+        let label = self
+            .row_timestamps
+            .as_ref()?
+            .get(&line_number)?
+            .label
+            .clone();
         Some(BatchedTextRun {
             row: row_index,
             col: 0,


### PR DESCRIPTION
## 问题

 时间戳此前以 row.line_id 存储和查询。滚动查看回滚时，快照会重新分配 line_id，导致同一行输出上的时间戳随滚动漂移，平滑滚动时还会闪烁。

 ## 修复

 改用稳定的会话坐标 scrollback_lines + absolute_line + 1 作为键，并新增共享辅助函数 terminal_line_number 统一使用：录制时按该键插入/更新/删
 除；修剪保留范围按 scrollback_lines + rows + 1 计算；元素查表使用同一坐标。

 该坐标对同一内容行不变：滚轮滚动时两项都不变；新输出到来时 scrollback_lines 加一、该行 absolute_line 减一，互相抵消。

 ## 测试

 - cargo check -p oxideterm-gpui-terminal
 - cargo test -p oxideterm-gpui-terminal row_timestamps
 - 更新 row_timestamps_track_last_modified_nonblank_content 以期望稳定键
 - 新增 row_timestamps_keep_the_same_key_across_scrollback_growth 锁定稳定键不变量
 - 在 Windows 11 上手动验证：滚动时时间戳跟随行内容、不再漂移