### PR TITLE
fix(terminal): keep timestamp keys stable across scrolling and eviction

### DIFF
--- a/crates/alacritty-terminal/src/grid/row.rs
+++ b/crates/alacritty-terminal/src/grid/row.rs
@@ -3,6 +3,7 @@
 use std::cmp::{max, min};
 use std::ops::{Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive};
 use std::{ptr, slice};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -12,9 +13,12 @@ use crate::index::Column;
 use crate::term::cell::ResetDiscriminant;
 
 /// A row in the grid.
-#[derive(Default, Clone, Debug)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Row<T> {
+    // Identity follows row swaps but changes when storage is recycled for new content.
+    #[cfg_attr(feature = "serde", serde(skip, default = "next_row_identity"))]
+    identity: usize,
     inner: Vec<T>,
 
     /// Maximum number of occupied entries.
@@ -22,6 +26,23 @@ pub struct Row<T> {
     /// This is the upper bound on the number of elements in the row, which have been modified
     /// since the last reset. All cells after this point are guaranteed to be equal.
     pub(crate) occ: usize,
+}
+
+fn next_row_identity() -> usize {
+    static NEXT: AtomicUsize = AtomicUsize::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+impl<T> Default for Row<T> {
+    fn default() -> Self {
+        Self { identity: next_row_identity(), inner: Vec::new(), occ: 0 }
+    }
+}
+
+impl<T: Clone> Clone for Row<T> {
+    fn clone(&self) -> Self {
+        Self { identity: next_row_identity(), inner: self.inner.clone(), occ: self.occ }
+    }
 }
 
 impl<T: PartialEq> PartialEq for Row<T> {
@@ -52,7 +73,7 @@ impl<T: Default> Row<T> {
             inner.set_len(columns);
         }
 
-        Row { inner, occ: 0 }
+        Row { identity: next_row_identity(), inner, occ: 0 }
     }
 
     /// Increase the number of columns in the row.
@@ -94,6 +115,7 @@ impl<T: Default> Row<T> {
         D: PartialEq,
     {
         debug_assert!(!self.inner.is_empty());
+        self.identity = next_row_identity();
 
         // Mark all cells as dirty if template cell changed.
         let len = self.inner.len();
@@ -112,9 +134,13 @@ impl<T: Default> Row<T> {
 
 #[allow(clippy::len_without_is_empty)]
 impl<T> Row<T> {
+    /// Stable source identity across viewport changes and movement in the grid.
+    #[inline]
+    pub fn identity(&self) -> usize { self.identity }
+
     #[inline]
     pub fn from_vec(vec: Vec<T>, occ: usize) -> Row<T> {
-        Row { inner: vec, occ }
+        Row { identity: next_row_identity(), inner: vec, occ }
     }
 
     #[inline]

--- a/crates/alacritty-terminal/src/grid/storage.rs
+++ b/crates/alacritty-terminal/src/grid/storage.rs
@@ -1,6 +1,5 @@
 use std::cmp::max;
 use std::mem;
-use std::mem::MaybeUninit;
 use std::ops::{Index, IndexMut};
 
 #[cfg(feature = "serde")]
@@ -142,37 +141,11 @@ impl<T> Storage<T> {
         self.len
     }
 
-    /// Swap implementation for Row<T>.
-    ///
-    /// Exploits the known size of Row<T> to produce a slightly more efficient
-    /// swap than going through slice::swap.
-    ///
-    /// The default implementation from swap generates 8 movups and 4 movaps
-    /// instructions. This implementation achieves the swap in only 8 movups
-    /// instructions.
+    /// Swap complete rows, including their source identities.
     pub fn swap(&mut self, a: Line, b: Line) {
-        debug_assert_eq!(mem::size_of::<Row<T>>(), mem::size_of::<usize>() * 4);
-
         let a = self.compute_index(a);
         let b = self.compute_index(b);
-
-        unsafe {
-            // Cast to a qword array to opt out of copy restrictions and avoid
-            // drop hazards. Byte array is no good here since for whatever
-            // reason LLVM won't optimized it.
-            let a_ptr = self.inner.as_mut_ptr().add(a) as *mut MaybeUninit<usize>;
-            let b_ptr = self.inner.as_mut_ptr().add(b) as *mut MaybeUninit<usize>;
-
-            // Copy 1 qword at a time.
-            //
-            // The optimizer unrolls this loop and vectorizes it.
-            let mut tmp: MaybeUninit<usize>;
-            for i in 0..4 {
-                tmp = *a_ptr.offset(i);
-                *a_ptr.offset(i) = *b_ptr.offset(i);
-                *b_ptr.offset(i) = tmp;
-            }
-        }
+        self.inner.swap(a, b);
     }
 
     /// Rotate the grid, moving all lines up/down in history.

--- a/crates/oxideterm-gpui-terminal/src/app.rs
+++ b/crates/oxideterm-gpui-terminal/src/app.rs
@@ -421,7 +421,7 @@ pub struct TerminalPane {
     terminal_timestamps_enabled: bool,
     // Visual-only metadata keyed by stable snapshot line identity; never write this
     // into the PTY buffer, copied text, or search/indexed terminal content.
-    row_timestamps: Arc<HashMap<u64, TerminalRowTimestamp>>,
+    row_timestamps: Arc<TerminalRowTimestampStore>,
     row_timestamp_retained_min_line: Option<u64>,
     metrics: TerminalMetrics,
     metrics_dirty: bool,
@@ -606,6 +606,22 @@ pub(crate) struct TerminalRowTimestamp {
     pub(crate) label: String,
     signature: u64,
     source_signature: u64,
+}
+
+/// Timestamp labels keyed by a window-relative line index plus an eviction
+/// base. The base advances whenever the scrollback cap evicts the oldest line,
+/// which shifts every retained line down one index; incrementing the base by
+/// the same amount keeps each absolute key stable across evictions.
+#[derive(Clone, Default)]
+pub(crate) struct TerminalRowTimestampStore {
+    pub(crate) base: u64,
+    pub(crate) entries: HashMap<u64, TerminalRowTimestamp>,
+}
+
+impl TerminalRowTimestampStore {
+    pub(crate) fn get(&self, index: u64) -> Option<&TerminalRowTimestamp> {
+        self.entries.get(&self.base.saturating_add(index))
+    }
 }
 
 #[derive(Clone)]
@@ -1071,7 +1087,7 @@ impl TerminalPane {
             snapshot_generation: 1,
             next_snapshot_line_id,
             terminal_timestamps_enabled: false,
-            row_timestamps: Arc::new(HashMap::new()),
+            row_timestamps: Arc::new(TerminalRowTimestampStore::default()),
             row_timestamp_retained_min_line: None,
             metrics,
             metrics_dirty: false,
@@ -1239,29 +1255,54 @@ impl TerminalPane {
         // Match iTerm-style semantics: a row label is the time that row was
         // last modified, not the time it first became visible in the viewport.
         let label = current_terminal_timestamp_label();
-        record_timestampable_snapshot_rows(
-            Arc::make_mut(&mut self.row_timestamps),
-            snapshot,
-            &label,
-        );
+        let store = Arc::make_mut(&mut self.row_timestamps);
+        if snapshot.scrollback_lines < self.snapshot.scrollback_lines {
+            // A shrunken history (clear, resize, or a lowered scrollback limit)
+            // re-anchors the window indices, so retained labels no longer map
+            // to their previous rows.
+            store.entries.clear();
+            store.base = 0;
+            self.row_timestamp_retained_min_line = None;
+        } else {
+            // The eviction count comes from surviving rows, not freshly assigned
+            // identities: viewport scrolling reveals rows that also take new
+            // line_ids without evicting anything.
+            store.base = store
+                .base
+                .saturating_add(timestamp_window_evictions(&self.snapshot, snapshot));
+        }
+        record_timestampable_snapshot_rows(store, snapshot, &label);
         self.trim_row_timestamps(snapshot);
     }
 
     fn trim_row_timestamps(&mut self, snapshot: &TerminalSnapshot) {
-        let Some(max_line) = snapshot.lines.iter().map(|row| row.line_id).max() else {
-            Arc::make_mut(&mut self.row_timestamps).clear();
+        let store = Arc::make_mut(&mut self.row_timestamps);
+        if snapshot.lines.is_empty() {
+            store.entries.clear();
+            store.base = 0;
             self.row_timestamp_retained_min_line = None;
             return;
-        };
+        }
+        let max_line = snapshot
+            .scrollback_lines
+            .saturating_add(snapshot.rows)
+            .saturating_add(1) as u64;
         let retained_rows = self
             .preferences
             .scrollback_lines
             .saturating_add(snapshot.rows)
             .saturating_add(1024)
             .max(2048) as u64;
-        let min_line = max_line.saturating_sub(retained_rows);
+        // Absolute keys live in [base, base + max_line); evicted lines and any
+        // history beyond the retention window sit below this shifted boundary.
+        let min_line = store.base.max(
+            store
+                .base
+                .saturating_add(max_line)
+                .saturating_sub(retained_rows),
+        );
         trim_row_timestamp_history(
-            Arc::make_mut(&mut self.row_timestamps),
+            &mut store.entries,
             &mut self.row_timestamp_retained_min_line,
             min_line,
         );
@@ -3794,16 +3835,51 @@ fn terminal_timestamp_label(hour: u32, minute: u32, second: u32, millis: u32) ->
     format!("[{hour:02}:{minute:02}:{second:02}.{millis:03}]")
 }
 
+/// Lines evicted by the scrollback cap in one snapshot step. Every surviving
+/// row keeps its line_id while eviction shifts its window-relative key down by
+/// the evicted count, so the largest key drop across surviving rows is the
+/// evicted count. Rows only revealed by viewport scrolling have no counterpart
+/// in the previous window and therefore contribute nothing.
+///
+/// When no row survives between the two snapshots (a single step that adds at
+/// least a full screen of lines while the cap is pinned), the evicted count is
+/// not observable from the viewport and the caller treats it as zero. Those
+/// history rows may be re-stamped once when scrolled into view, then recover.
+fn timestamp_window_evictions(previous: &TerminalSnapshot, next: &TerminalSnapshot) -> u64 {
+    let previous_indices = previous
+        .lines
+        .iter()
+        .filter(|row| row.line_id != 0)
+        .map(|row| (row.line_id, terminal_row_timestamp_index(previous, row)))
+        .collect::<HashMap<_, _>>();
+    let mut evictions = 0;
+    for row in &next.lines {
+        if row.line_id == 0 {
+            continue;
+        }
+        let Some(previous_index) = previous_indices.get(&row.line_id) else {
+            continue;
+        };
+        let next_index = terminal_row_timestamp_index(next, row);
+        evictions = evictions.max(previous_index.saturating_sub(next_index));
+    }
+    evictions
+}
+
 fn record_timestampable_snapshot_rows(
-    row_timestamps: &mut HashMap<u64, TerminalRowTimestamp>,
+    store: &mut TerminalRowTimestampStore,
     snapshot: &TerminalSnapshot,
     label: &str,
 ) {
     for row in &snapshot.lines {
+        let key = store
+            .base
+            .saturating_add(terminal_row_timestamp_index(snapshot, row));
         // The snapshot signature is a cheap invalidation key. Cursor-only changes
         // still fall through to the content signature comparison below.
-        if row_timestamps
-            .get(&row.line_id)
+        if store
+            .entries
+            .get(&key)
             .is_some_and(|timestamp| timestamp.source_signature == row.signature)
         {
             continue;
@@ -3811,15 +3887,15 @@ fn record_timestampable_snapshot_rows(
 
         if terminal_row_has_timestamp_content(row) {
             let timestamp_signature = terminal_row_timestamp_signature(row);
-            if let Some(timestamp) = row_timestamps.get_mut(&row.line_id) {
+            if let Some(timestamp) = store.entries.get_mut(&key) {
                 if timestamp.signature != timestamp_signature {
                     timestamp.label = label.to_string();
                     timestamp.signature = timestamp_signature;
                 }
                 timestamp.source_signature = row.signature;
             } else {
-                row_timestamps.insert(
-                    row.line_id,
+                store.entries.insert(
+                    key,
                     TerminalRowTimestamp {
                         label: label.to_string(),
                         signature: timestamp_signature,
@@ -3830,7 +3906,7 @@ fn record_timestampable_snapshot_rows(
         } else {
             // Blank viewport rows are recycled later. Removing their metadata
             // prevents new output from inheriting a stale line-modification time.
-            row_timestamps.remove(&row.line_id);
+            store.entries.remove(&key);
         }
     }
 }
@@ -4269,6 +4345,32 @@ mod tests {
         }
     }
 
+    fn timestamp_window_test_snapshot(
+        scrollback_lines: usize,
+        rows: &[(u64, i64)],
+    ) -> TerminalSnapshot {
+        let lines = rows
+            .iter()
+            .map(|&(line_id, absolute_line)| {
+                let mut row = timestamp_test_row(absolute_line, "x");
+                row.line_id = line_id;
+                row
+            })
+            .collect::<Vec<_>>();
+        TerminalSnapshot {
+            generation: 1,
+            cols: 1,
+            rows: rows.len(),
+            cursor_col: 0,
+            cursor_row: 0,
+            cursor_shape: TerminalCursorShape::Block,
+            display_offset: 0,
+            scrollback_lines,
+            lines,
+            images: Vec::new(),
+        }
+    }
+
     #[test]
     fn snapshot_line_ids_follow_scrolled_sources_without_reusing_recycled_rows() {
         let mut previous_lines = (0..3)
@@ -4314,26 +4416,25 @@ mod tests {
 
     #[test]
     fn row_timestamps_track_last_modified_nonblank_content() {
-        let mut row_timestamps = HashMap::new();
+        let mut store = TerminalRowTimestampStore::default();
         let blank_snapshot = timestamp_test_snapshot(timestamp_test_row(42, "   "));
-        record_timestampable_snapshot_rows(&mut row_timestamps, &blank_snapshot, "10:00:00");
+        record_timestampable_snapshot_rows(&mut store, &blank_snapshot, "10:00:00");
 
-        assert!(!row_timestamps.contains_key(&42));
+        // Stable key: base(0) + scrollback(0) + absolute_line(42) = 42.
+        assert!(!store.entries.contains_key(&42));
 
         let content_snapshot = timestamp_test_snapshot(timestamp_test_row(42, "ls"));
-        record_timestampable_snapshot_rows(&mut row_timestamps, &content_snapshot, "10:00:01");
+        record_timestampable_snapshot_rows(&mut store, &content_snapshot, "10:00:01");
 
         assert_eq!(
-            row_timestamps
-                .get(&42)
-                .map(|timestamp| timestamp.label.as_str()),
+            store.get(42).map(|timestamp| timestamp.label.as_str()),
             Some("10:00:01")
         );
 
         let unchanged_snapshot =
             timestamp_test_snapshot(timestamp_test_row_with_cursor(42, "ls", Some(1), true));
-        record_timestampable_snapshot_rows(&mut row_timestamps, &unchanged_snapshot, "10:00:02");
-        let unchanged_timestamp = row_timestamps.get(&42).expect("timestamped row");
+        record_timestampable_snapshot_rows(&mut store, &unchanged_snapshot, "10:00:02");
+        let unchanged_timestamp = store.get(42).expect("timestamped row");
         assert_eq!(unchanged_timestamp.label, "10:00:01");
         assert_eq!(
             unchanged_timestamp.source_signature,
@@ -4341,11 +4442,9 @@ mod tests {
         );
 
         let changed_snapshot = timestamp_test_snapshot(timestamp_test_row(42, "pwd"));
-        record_timestampable_snapshot_rows(&mut row_timestamps, &changed_snapshot, "10:00:03");
+        record_timestampable_snapshot_rows(&mut store, &changed_snapshot, "10:00:03");
         assert_eq!(
-            row_timestamps
-                .get(&42)
-                .map(|timestamp| timestamp.label.as_str()),
+            store.get(42).map(|timestamp| timestamp.label.as_str()),
             Some("10:00:03")
         );
 
@@ -4354,9 +4453,117 @@ mod tests {
         assert_eq!(label.chars().count(), TERMINAL_TIMESTAMP_LABEL_CELLS);
 
         let cleared_snapshot = timestamp_test_snapshot(timestamp_test_row(42, ""));
-        record_timestampable_snapshot_rows(&mut row_timestamps, &cleared_snapshot, "10:00:04");
+        record_timestampable_snapshot_rows(&mut store, &cleared_snapshot, "10:00:04");
 
-        assert!(!row_timestamps.contains_key(&42));
+        assert!(!store.entries.contains_key(&42));
+    }
+
+    #[test]
+    fn row_timestamps_keep_the_same_key_across_scrollback_growth() {
+        let mut store = TerminalRowTimestampStore::default();
+
+        // The content row sits on the screen with one scrollback line, so its
+        // stable key is base(0) + scrollback(1) + absolute_line(0) = 1.
+        let mut first_snapshot = timestamp_test_snapshot(timestamp_test_row(0, "ls"));
+        first_snapshot.scrollback_lines = 1;
+        record_timestampable_snapshot_rows(&mut store, &first_snapshot, "10:00:01");
+        assert_eq!(
+            store.get(1).map(|timestamp| timestamp.label.as_str()),
+            Some("10:00:01")
+        );
+
+        // New output pushes the same content into scrollback: scrollback grows
+        // by one while absolute_line drops by one, so the key must stay 1 and
+        // the label must not be re-stamped.
+        let mut second_snapshot = timestamp_test_snapshot(timestamp_test_row(-1, "ls"));
+        second_snapshot.scrollback_lines = 2;
+        record_timestampable_snapshot_rows(&mut store, &second_snapshot, "10:00:02");
+        assert_eq!(
+            store.get(1).map(|timestamp| timestamp.label.as_str()),
+            Some("10:00:01"),
+            "scrolling must not re-stamp the same content line"
+        );
+    }
+
+    #[test]
+    fn row_timestamps_survive_scrollback_cap_eviction_without_restamping() {
+        let mut store = TerminalRowTimestampStore::default();
+
+        // The buffer cap has been reached: scrollback is pinned at 2. The
+        // content row sits on the screen, so its key is base(0) +
+        // scrollback(2) + absolute_line(0) = 2.
+        let mut before_eviction = timestamp_test_snapshot(timestamp_test_row(0, "ls"));
+        before_eviction.scrollback_lines = 2;
+        record_timestampable_snapshot_rows(&mut store, &before_eviction, "10:00:01");
+
+        // The cap evicts the oldest history line while the same content moves
+        // up one row without scrollback growth. Advancing the base by the one
+        // evicted line keeps the same absolute key; the label must follow the
+        // content instead of being re-stamped.
+        store.base += 1;
+        let mut after_eviction = timestamp_test_snapshot(timestamp_test_row(-1, "ls"));
+        after_eviction.scrollback_lines = 2;
+        record_timestampable_snapshot_rows(&mut store, &after_eviction, "10:00:02");
+
+        assert_eq!(
+            store.get(1).map(|timestamp| timestamp.label.as_str()),
+            Some("10:00:01"),
+            "cap eviction must not re-stamp the same content line"
+        );
+    }
+
+    #[test]
+    fn timestamp_window_evictions_ignores_viewport_scroll_up() {
+        // Scrolling up reveals one history row at the top; the two surviving
+        // rows keep their line identities and their window-relative keys.
+        let previous = timestamp_window_test_snapshot(5, &[(10, 0), (11, 1), (12, 2)]);
+        let next = timestamp_window_test_snapshot(5, &[(0, -1), (10, 0), (11, 1)]);
+        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
+    }
+
+    #[test]
+    fn timestamp_window_evictions_ignores_viewport_scroll_down() {
+        // Scrolling down reveals one screen row at the bottom without evicting
+        // history, so the base must not advance.
+        let previous = timestamp_window_test_snapshot(5, &[(10, -1), (11, 0), (12, 1)]);
+        let next = timestamp_window_test_snapshot(5, &[(10, 0), (11, 1), (0, 2)]);
+        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
+    }
+
+    #[test]
+    fn timestamp_window_evictions_ignores_full_viewport_jumps() {
+        // Jumping Home rebuilds the whole window with fresh identities. No row
+        // survives the jump, so nothing was evicted.
+        let previous = timestamp_window_test_snapshot(10, &[(10, 0), (11, 1), (12, 2)]);
+        let next = timestamp_window_test_snapshot(10, &[(0, -10), (0, -9), (0, -8)]);
+        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
+    }
+
+    #[test]
+    fn timestamp_window_evictions_ignores_scrollback_growth() {
+        // One new output line grows history by one, which exactly absorbs the
+        // key shift of every surviving row.
+        let previous = timestamp_window_test_snapshot(2, &[(10, 0), (11, 1), (12, 2), (13, 3)]);
+        let next = timestamp_window_test_snapshot(3, &[(11, 0), (12, 1), (13, 2), (14, 3)]);
+        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
+    }
+
+    #[test]
+    fn timestamp_window_evictions_counts_cap_evictions() {
+        // Two new output lines while history is pinned at its cap evict the
+        // two oldest lines, shifting every surviving key down by two.
+        let previous = timestamp_window_test_snapshot(5, &[(10, 0), (11, 1), (12, 2), (13, 3)]);
+        let next = timestamp_window_test_snapshot(5, &[(12, 0), (13, 1), (14, 2), (15, 3)]);
+        assert_eq!(timestamp_window_evictions(&previous, &next), 2);
+    }
+
+    #[test]
+    fn timestamp_window_evictions_counts_cap_evictions_while_scrolled() {
+        // Output while the viewport is scrolled still shifts surviving rows by
+        // the evicted count, while rows revealed by the scroll contribute zero.
+        let previous = timestamp_window_test_snapshot(5, &[(10, -3), (11, -2), (12, -1), (13, 0)]);
+        let next = timestamp_window_test_snapshot(5, &[(11, -3), (12, -2), (13, -1), (0, 0)]);
+        assert_eq!(timestamp_window_evictions(&previous, &next), 1);
     }
 
     #[test]

--- a/crates/oxideterm-gpui-terminal/src/app.rs
+++ b/crates/oxideterm-gpui-terminal/src/app.rs
@@ -422,7 +422,6 @@ pub struct TerminalPane {
     // Visual-only metadata keyed by stable snapshot line identity; never write this
     // into the PTY buffer, copied text, or search/indexed terminal content.
     row_timestamps: Arc<TerminalRowTimestampStore>,
-    row_timestamp_retained_min_line: Option<u64>,
     metrics: TerminalMetrics,
     metrics_dirty: bool,
     selection: Option<TerminalSelection>,
@@ -608,19 +607,15 @@ pub(crate) struct TerminalRowTimestamp {
     source_signature: u64,
 }
 
-/// Timestamp labels keyed by a window-relative line index plus an eviction
-/// base. The base advances whenever the scrollback cap evicts the oldest line,
-/// which shifts every retained line down one index; incrementing the base by
-/// the same amount keeps each absolute key stable across evictions.
+/// Visual metadata follows the emulator row, independent of viewport coordinates.
 #[derive(Clone, Default)]
 pub(crate) struct TerminalRowTimestampStore {
-    pub(crate) base: u64,
     pub(crate) entries: HashMap<u64, TerminalRowTimestamp>,
 }
 
 impl TerminalRowTimestampStore {
-    pub(crate) fn get(&self, index: u64) -> Option<&TerminalRowTimestamp> {
-        self.entries.get(&self.base.saturating_add(index))
+    pub(crate) fn get(&self, identity: u64) -> Option<&TerminalRowTimestamp> {
+        self.entries.get(&identity)
     }
 }
 
@@ -1088,7 +1083,6 @@ impl TerminalPane {
             next_snapshot_line_id,
             terminal_timestamps_enabled: false,
             row_timestamps: Arc::new(TerminalRowTimestampStore::default()),
-            row_timestamp_retained_min_line: None,
             metrics,
             metrics_dirty: false,
             selection: None,
@@ -1256,21 +1250,6 @@ impl TerminalPane {
         // last modified, not the time it first became visible in the viewport.
         let label = current_terminal_timestamp_label();
         let store = Arc::make_mut(&mut self.row_timestamps);
-        if snapshot.scrollback_lines < self.snapshot.scrollback_lines {
-            // A shrunken history (clear, resize, or a lowered scrollback limit)
-            // re-anchors the window indices, so retained labels no longer map
-            // to their previous rows.
-            store.entries.clear();
-            store.base = 0;
-            self.row_timestamp_retained_min_line = None;
-        } else {
-            // The eviction count comes from surviving rows, not freshly assigned
-            // identities: viewport scrolling reveals rows that also take new
-            // line_ids without evicting anything.
-            store.base = store
-                .base
-                .saturating_add(timestamp_window_evictions(&self.snapshot, snapshot));
-        }
         record_timestampable_snapshot_rows(store, snapshot, &label);
         self.trim_row_timestamps(snapshot);
     }
@@ -1279,33 +1258,15 @@ impl TerminalPane {
         let store = Arc::make_mut(&mut self.row_timestamps);
         if snapshot.lines.is_empty() {
             store.entries.clear();
-            store.base = 0;
-            self.row_timestamp_retained_min_line = None;
             return;
         }
-        let max_line = snapshot
-            .scrollback_lines
-            .saturating_add(snapshot.rows)
-            .saturating_add(1) as u64;
         let retained_rows = self
             .preferences
             .scrollback_lines
             .saturating_add(snapshot.rows)
             .saturating_add(1024)
-            .max(2048) as u64;
-        // Absolute keys live in [base, base + max_line); evicted lines and any
-        // history beyond the retention window sit below this shifted boundary.
-        let min_line = store.base.max(
-            store
-                .base
-                .saturating_add(max_line)
-                .saturating_sub(retained_rows),
-        );
-        trim_row_timestamp_history(
-            &mut store.entries,
-            &mut self.row_timestamp_retained_min_line,
-            min_line,
-        );
+            .max(2048);
+        trim_row_timestamp_history(&mut store.entries, retained_rows);
     }
 
     pub fn terminal_timestamps_enabled(&self) -> bool {
@@ -3835,46 +3796,16 @@ fn terminal_timestamp_label(hour: u32, minute: u32, second: u32, millis: u32) ->
     format!("[{hour:02}:{minute:02}:{second:02}.{millis:03}]")
 }
 
-/// Lines evicted by the scrollback cap in one snapshot step. Every surviving
-/// row keeps its line_id while eviction shifts its window-relative key down by
-/// the evicted count, so the largest key drop across surviving rows is the
-/// evicted count. Rows only revealed by viewport scrolling have no counterpart
-/// in the previous window and therefore contribute nothing.
-///
-/// When no row survives between the two snapshots (a single step that adds at
-/// least a full screen of lines while the cap is pinned), the evicted count is
-/// not observable from the viewport and the caller treats it as zero. Those
-/// history rows may be re-stamped once when scrolled into view, then recover.
-fn timestamp_window_evictions(previous: &TerminalSnapshot, next: &TerminalSnapshot) -> u64 {
-    let previous_indices = previous
-        .lines
-        .iter()
-        .filter(|row| row.line_id != 0)
-        .map(|row| (row.line_id, terminal_row_timestamp_index(previous, row)))
-        .collect::<HashMap<_, _>>();
-    let mut evictions = 0;
-    for row in &next.lines {
-        if row.line_id == 0 {
-            continue;
-        }
-        let Some(previous_index) = previous_indices.get(&row.line_id) else {
-            continue;
-        };
-        let next_index = terminal_row_timestamp_index(next, row);
-        evictions = evictions.max(previous_index.saturating_sub(next_index));
-    }
-    evictions
-}
-
 fn record_timestampable_snapshot_rows(
     store: &mut TerminalRowTimestampStore,
     snapshot: &TerminalSnapshot,
     label: &str,
 ) {
     for row in &snapshot.lines {
-        let key = store
-            .base
-            .saturating_add(terminal_row_timestamp_index(snapshot, row));
+        let key = terminal_row_timestamp_identity(row);
+        if key == 0 {
+            continue;
+        }
         // The snapshot signature is a cheap invalidation key. Cursor-only changes
         // still fall through to the content signature comparison below.
         if store
@@ -3913,34 +3844,18 @@ fn record_timestampable_snapshot_rows(
 
 fn trim_row_timestamp_history(
     row_timestamps: &mut HashMap<u64, TerminalRowTimestamp>,
-    retained_min_line: &mut Option<u64>,
-    min_line: u64,
+    retained_rows: usize,
 ) {
-    let Some(previous_min_line) = *retained_min_line else {
-        row_timestamps.retain(|line, _| *line >= min_line);
-        *retained_min_line = Some(min_line);
-        return;
-    };
-
-    if min_line <= previous_min_line {
-        // Snapshot identity can restart when a pane is rebuilt. New rows may then be inserted
-        // below the former boundary, so restart incremental trimming from this identity.
-        *retained_min_line = Some(min_line);
+    // IDs are process-wide; other terminals can make them arbitrarily sparse.
+    // Batch pruning bounds memory without scanning the cache on every frame.
+    if row_timestamps.len() <= retained_rows.saturating_add(1024) {
         return;
     }
-
-    let advanced_lines =
-        usize::try_from(min_line.saturating_sub(previous_min_line)).unwrap_or(usize::MAX);
-    if advanced_lines < row_timestamps.len() {
-        // Normal scrolling advances by only a few rows. Removing those keys is
-        // cheaper than scanning the entire retained timestamp history.
-        for line in previous_min_line..min_line {
-            row_timestamps.remove(&line);
-        }
-    } else {
-        row_timestamps.retain(|line, _| *line >= min_line);
-    }
-    *retained_min_line = Some(min_line);
+    let mut identities: Vec<_> = row_timestamps.keys().copied().collect();
+    let remove_count = identities.len() - retained_rows;
+    identities.select_nth_unstable(remove_count);
+    let min_identity = identities[remove_count];
+    row_timestamps.retain(|identity, _| *identity >= min_identity);
 }
 
 fn terminal_row_timestamp_signature(row: &TerminalRow) -> u64 {
@@ -4319,7 +4234,7 @@ mod tests {
         }
         let mut row = TerminalRow {
             line_id: absolute_line.max(0) as u64,
-            source_id: 0,
+            source_id: absolute_line.max(0) as usize,
             absolute_line,
             cells: Arc::new(cells),
             wrapped: false,
@@ -4341,32 +4256,6 @@ mod tests {
             display_offset: 0,
             scrollback_lines: 0,
             lines: vec![row],
-            images: Vec::new(),
-        }
-    }
-
-    fn timestamp_window_test_snapshot(
-        scrollback_lines: usize,
-        rows: &[(u64, i64)],
-    ) -> TerminalSnapshot {
-        let lines = rows
-            .iter()
-            .map(|&(line_id, absolute_line)| {
-                let mut row = timestamp_test_row(absolute_line, "x");
-                row.line_id = line_id;
-                row
-            })
-            .collect::<Vec<_>>();
-        TerminalSnapshot {
-            generation: 1,
-            cols: 1,
-            rows: rows.len(),
-            cursor_col: 0,
-            cursor_row: 0,
-            cursor_shape: TerminalCursorShape::Block,
-            display_offset: 0,
-            scrollback_lines,
-            lines,
             images: Vec::new(),
         }
     }
@@ -4420,7 +4309,7 @@ mod tests {
         let blank_snapshot = timestamp_test_snapshot(timestamp_test_row(42, "   "));
         record_timestampable_snapshot_rows(&mut store, &blank_snapshot, "10:00:00");
 
-        // Stable key: base(0) + scrollback(0) + absolute_line(42) = 42.
+        // This fixture uses emulator source identity 42.
         assert!(!store.entries.contains_key(&42));
 
         let content_snapshot = timestamp_test_snapshot(timestamp_test_row(42, "ls"));
@@ -4459,140 +4348,94 @@ mod tests {
     }
 
     #[test]
-    fn row_timestamps_keep_the_same_key_across_scrollback_growth() {
+    fn timestamp_identity_survives_burst_output_and_viewport_jumps() {
+        let mut terminal =
+            TerminalSession::recording_playback(20, 3, GraphicsOptions::default(), 10);
+        terminal.feed_recording_output(b"same\r\nsame\r\nsame\r\nsame\r\nsame\r\nsame\r\nsame\r\nsame\r\nsame\r\nsame\r\nkept\r\nsame");
+        let before = terminal.snapshot();
+        let kept = before
+            .lines
+            .iter()
+            .find(|row| row.text().trim() == "kept")
+            .unwrap();
+        let original_key = terminal_row_timestamp_identity(kept);
         let mut store = TerminalRowTimestampStore::default();
-
-        // The content row sits on the screen with one scrollback line, so its
-        // stable key is base(0) + scrollback(1) + absolute_line(0) = 1.
-        let mut first_snapshot = timestamp_test_snapshot(timestamp_test_row(0, "ls"));
-        first_snapshot.scrollback_lines = 1;
-        record_timestampable_snapshot_rows(&mut store, &first_snapshot, "10:00:01");
-        assert_eq!(
-            store.get(1).map(|timestamp| timestamp.label.as_str()),
-            Some("10:00:01")
-        );
-
-        // New output pushes the same content into scrollback: scrollback grows
-        // by one while absolute_line drops by one, so the key must stay 1 and
-        // the label must not be re-stamped.
-        let mut second_snapshot = timestamp_test_snapshot(timestamp_test_row(-1, "ls"));
-        second_snapshot.scrollback_lines = 2;
-        record_timestampable_snapshot_rows(&mut store, &second_snapshot, "10:00:02");
-        assert_eq!(
-            store.get(1).map(|timestamp| timestamp.label.as_str()),
-            Some("10:00:01"),
-            "scrolling must not re-stamp the same content line"
-        );
+        record_timestampable_snapshot_rows(&mut store, &before, "old");
+        terminal.feed_recording_output(b"\r\nsame\r\nsame\r\nsame\r\nsame");
+        let after = terminal.snapshot();
+        record_timestampable_snapshot_rows(&mut store, &after, "new");
+        for row in after.lines.iter().filter(|row| row.text().trim() == "same") {
+            assert_eq!(
+                store
+                    .get(terminal_row_timestamp_identity(row))
+                    .unwrap()
+                    .label,
+                "new"
+            );
+        }
+        terminal.scroll_to_top();
+        let top = terminal.snapshot();
+        record_timestampable_snapshot_rows(&mut store, &top, "scroll");
+        terminal.scroll_to_display_offset(4);
+        let historical = terminal.snapshot();
+        let kept = historical
+            .lines
+            .iter()
+            .find(|row| row.text().trim() == "kept")
+            .unwrap();
+        record_timestampable_snapshot_rows(&mut store, &historical, "scroll");
+        assert_eq!(terminal_row_timestamp_identity(kept), original_key);
+        assert_eq!(store.get(original_key).unwrap().label, "old");
     }
 
     #[test]
-    fn row_timestamps_survive_scrollback_cap_eviction_without_restamping() {
+    fn timestamp_identity_follows_local_line_deletion_without_moving_other_rows() {
+        let mut terminal =
+            TerminalSession::recording_playback(20, 4, GraphicsOptions::default(), 10);
+        terminal.feed_recording_output(b"fixed\r\nremoved\r\nkept\r\nlast");
+        let before = terminal.snapshot();
         let mut store = TerminalRowTimestampStore::default();
-
-        // The buffer cap has been reached: scrollback is pinned at 2. The
-        // content row sits on the screen, so its key is base(0) +
-        // scrollback(2) + absolute_line(0) = 2.
-        let mut before_eviction = timestamp_test_snapshot(timestamp_test_row(0, "ls"));
-        before_eviction.scrollback_lines = 2;
-        record_timestampable_snapshot_rows(&mut store, &before_eviction, "10:00:01");
-
-        // The cap evicts the oldest history line while the same content moves
-        // up one row without scrollback growth. Advancing the base by the one
-        // evicted line keeps the same absolute key; the label must follow the
-        // content instead of being re-stamped.
-        store.base += 1;
-        let mut after_eviction = timestamp_test_snapshot(timestamp_test_row(-1, "ls"));
-        after_eviction.scrollback_lines = 2;
-        record_timestampable_snapshot_rows(&mut store, &after_eviction, "10:00:02");
-
-        assert_eq!(
-            store.get(1).map(|timestamp| timestamp.label.as_str()),
-            Some("10:00:01"),
-            "cap eviction must not re-stamp the same content line"
-        );
+        record_timestampable_snapshot_rows(&mut store, &before, "old");
+        terminal.feed_recording_output(b"\x1b[2;1H\x1b[M");
+        let after = terminal.snapshot();
+        assert_eq!(after.scrollback_lines, before.scrollback_lines);
+        record_timestampable_snapshot_rows(&mut store, &after, "new");
+        for text in ["fixed", "kept", "last"] {
+            let row = after
+                .lines
+                .iter()
+                .find(|row| row.text().trim() == text)
+                .unwrap();
+            assert_eq!(
+                store
+                    .get(terminal_row_timestamp_identity(row))
+                    .unwrap()
+                    .label,
+                "old",
+                "{text}"
+            );
+        }
     }
 
     #[test]
-    fn timestamp_window_evictions_ignores_viewport_scroll_up() {
-        // Scrolling up reveals one history row at the top; the two surviving
-        // rows keep their line identities and their window-relative keys.
-        let previous = timestamp_window_test_snapshot(5, &[(10, 0), (11, 1), (12, 2)]);
-        let next = timestamp_window_test_snapshot(5, &[(0, -1), (10, 0), (11, 1)]);
-        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
-    }
-
-    #[test]
-    fn timestamp_window_evictions_ignores_viewport_scroll_down() {
-        // Scrolling down reveals one screen row at the bottom without evicting
-        // history, so the base must not advance.
-        let previous = timestamp_window_test_snapshot(5, &[(10, -1), (11, 0), (12, 1)]);
-        let next = timestamp_window_test_snapshot(5, &[(10, 0), (11, 1), (0, 2)]);
-        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
-    }
-
-    #[test]
-    fn timestamp_window_evictions_ignores_full_viewport_jumps() {
-        // Jumping Home rebuilds the whole window with fresh identities. No row
-        // survives the jump, so nothing was evicted.
-        let previous = timestamp_window_test_snapshot(10, &[(10, 0), (11, 1), (12, 2)]);
-        let next = timestamp_window_test_snapshot(10, &[(0, -10), (0, -9), (0, -8)]);
-        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
-    }
-
-    #[test]
-    fn timestamp_window_evictions_ignores_scrollback_growth() {
-        // One new output line grows history by one, which exactly absorbs the
-        // key shift of every surviving row.
-        let previous = timestamp_window_test_snapshot(2, &[(10, 0), (11, 1), (12, 2), (13, 3)]);
-        let next = timestamp_window_test_snapshot(3, &[(11, 0), (12, 1), (13, 2), (14, 3)]);
-        assert_eq!(timestamp_window_evictions(&previous, &next), 0);
-    }
-
-    #[test]
-    fn timestamp_window_evictions_counts_cap_evictions() {
-        // Two new output lines while history is pinned at its cap evict the
-        // two oldest lines, shifting every surviving key down by two.
-        let previous = timestamp_window_test_snapshot(5, &[(10, 0), (11, 1), (12, 2), (13, 3)]);
-        let next = timestamp_window_test_snapshot(5, &[(12, 0), (13, 1), (14, 2), (15, 3)]);
-        assert_eq!(timestamp_window_evictions(&previous, &next), 2);
-    }
-
-    #[test]
-    fn timestamp_window_evictions_counts_cap_evictions_while_scrolled() {
-        // Output while the viewport is scrolled still shifts surviving rows by
-        // the evicted count, while rows revealed by the scroll contribute zero.
-        let previous = timestamp_window_test_snapshot(5, &[(10, -3), (11, -2), (12, -1), (13, 0)]);
-        let next = timestamp_window_test_snapshot(5, &[(11, -3), (12, -2), (13, -1), (0, 0)]);
-        assert_eq!(timestamp_window_evictions(&previous, &next), 1);
-    }
-
-    #[test]
-    fn row_timestamp_history_trims_incrementally_and_handles_rewind() {
-        let timestamp = |line: u64| TerminalRowTimestamp {
-            label: line.to_string(),
-            signature: line,
-            source_signature: line,
+    fn timestamp_cache_bounds_sparse_identities_and_revisited_history() {
+        let timestamp = |id: u64| TerminalRowTimestamp {
+            label: id.to_string(),
+            signature: id,
+            source_signature: id,
         };
-        let mut row_timestamps = (0..6)
-            .map(|line| (line, timestamp(line)))
+        let mut entries = (0..1100)
+            .map(|id| (id * 1000, timestamp(id)))
             .collect::<HashMap<_, _>>();
-        let mut retained_min_line = None;
-
-        trim_row_timestamp_history(&mut row_timestamps, &mut retained_min_line, 2);
-        assert_eq!(retained_min_line, Some(2));
-        assert_eq!(row_timestamps.len(), 4);
-        assert!(row_timestamps.keys().all(|line| *line >= 2));
-
-        trim_row_timestamp_history(&mut row_timestamps, &mut retained_min_line, 4);
-        assert_eq!(retained_min_line, Some(4));
-        assert_eq!(row_timestamps.len(), 2);
-        assert!(row_timestamps.keys().all(|line| *line >= 4));
-
-        trim_row_timestamp_history(&mut row_timestamps, &mut retained_min_line, 1);
-        row_timestamps.insert(1, timestamp(1));
-        trim_row_timestamp_history(&mut row_timestamps, &mut retained_min_line, 3);
-        assert_eq!(retained_min_line, Some(3));
-        assert!(!row_timestamps.contains_key(&1));
+        trim_row_timestamp_history(&mut entries, 50);
+        assert_eq!(entries.len(), 50);
+        assert!(entries.contains_key(&1_099_000));
+        for id in 0..1100 {
+            entries.insert(id, timestamp(id));
+        }
+        trim_row_timestamp_history(&mut entries, 50);
+        assert_eq!(entries.len(), 50);
+        assert!(!entries.contains_key(&1));
     }
 
     #[gpui::test]

--- a/crates/oxideterm-gpui-terminal/src/terminal_ui.rs
+++ b/crates/oxideterm-gpui-terminal/src/terminal_ui.rs
@@ -9,7 +9,8 @@ use oxideterm_settings::{
     TerminalBackspaceSequence, TerminalDeleteSequence, TerminalSemanticScheme,
 };
 use oxideterm_terminal::{
-    TerminalColor, TerminalCursorShape, TerminalEncoding, TrzszTransferPolicy,
+    TerminalColor, TerminalCursorShape, TerminalEncoding, TerminalRow, TerminalSnapshot,
+    TrzszTransferPolicy,
 };
 use oxideterm_terminal_semantic::{
     CompiledSemanticScheme, SemanticClass, SemanticScheme, SemanticSchemeDocument,
@@ -1021,6 +1022,13 @@ pub(crate) fn terminal_timestamp_gutter_width(metrics: &TerminalMetrics, enabled
     } else {
         0.0
     }
+}
+
+/// Window-relative identity for a retained line. It starts at zero for the
+/// oldest history row, stays stable while scrolling, and the timestamp store's
+/// eviction base keeps the resulting absolute key stable across cap evictions.
+pub(crate) fn terminal_row_timestamp_index(snapshot: &TerminalSnapshot, row: &TerminalRow) -> u64 {
+    (snapshot.scrollback_lines as i64 + row.absolute_line).max(0) as u64
 }
 
 pub(crate) fn fallback_cell_width(window: &mut Window, font: &Font, font_size: Pixels) -> Pixels {

--- a/crates/oxideterm-gpui-terminal/src/terminal_ui.rs
+++ b/crates/oxideterm-gpui-terminal/src/terminal_ui.rs
@@ -9,8 +9,7 @@ use oxideterm_settings::{
     TerminalBackspaceSequence, TerminalDeleteSequence, TerminalSemanticScheme,
 };
 use oxideterm_terminal::{
-    TerminalColor, TerminalCursorShape, TerminalEncoding, TerminalRow, TerminalSnapshot,
-    TrzszTransferPolicy,
+    TerminalColor, TerminalCursorShape, TerminalEncoding, TerminalRow, TrzszTransferPolicy,
 };
 use oxideterm_terminal_semantic::{
     CompiledSemanticScheme, SemanticClass, SemanticScheme, SemanticSchemeDocument,
@@ -1024,11 +1023,9 @@ pub(crate) fn terminal_timestamp_gutter_width(metrics: &TerminalMetrics, enabled
     }
 }
 
-/// Window-relative identity for a retained line. It starts at zero for the
-/// oldest history row, stays stable while scrolling, and the timestamp store's
-/// eviction base keeps the resulting absolute key stable across cap evictions.
-pub(crate) fn terminal_row_timestamp_index(snapshot: &TerminalSnapshot, row: &TerminalRow) -> u64 {
-    (snapshot.scrollback_lines as i64 + row.absolute_line).max(0) as u64
+/// Emulator-owned identity is stable across scrolling, eviction and local row movement.
+pub(crate) fn terminal_row_timestamp_identity(row: &TerminalRow) -> u64 {
+    row.source_id as u64
 }
 
 pub(crate) fn fallback_cell_width(window: &mut Window, font: &Font, font_size: Pixels) -> Pixels {

--- a/crates/oxideterm-gpui-terminal/src/terminal_view/element.rs
+++ b/crates/oxideterm-gpui-terminal/src/terminal_view/element.rs
@@ -23,7 +23,9 @@ use oxideterm_terminal_unicode::{TerminalVisualLine, visual_line_for_row_if_bidi
 use parking_lot::Mutex;
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::{TerminalInputHandler, TerminalPane, TerminalRenderedImage, TerminalRowTimestamp};
+use crate::app::{
+    TerminalInputHandler, TerminalPane, TerminalRenderedImage, TerminalRowTimestampStore,
+};
 use crate::command_facts::TransientCommandHighlight;
 use crate::terminal_ui::*;
 use crate::terminal_view::highlight::{TerminalHighlightLayout, terminal_highlights_for_rows};
@@ -77,7 +79,7 @@ pub(crate) struct TerminalElement {
     bidi_enabled: bool,
     input: Option<TerminalElementInput>,
     transparent_background: bool,
-    row_timestamps: Option<Arc<HashMap<u64, TerminalRowTimestamp>>>,
+    row_timestamps: Option<Arc<TerminalRowTimestampStore>>,
     layout_cache: Option<Arc<Mutex<TerminalLayoutCache>>>,
     performance_metrics_enabled: bool,
     viewport_rows: usize,
@@ -665,7 +667,7 @@ impl TerminalElement {
 
     pub(crate) fn row_timestamps(
         mut self,
-        row_timestamps: Option<Arc<HashMap<u64, TerminalRowTimestamp>>>,
+        row_timestamps: Option<Arc<TerminalRowTimestampStore>>,
     ) -> Self {
         self.row_timestamps = row_timestamps;
         self
@@ -863,7 +865,9 @@ impl TerminalElement {
                     &mut cursor,
                 );
             }
-            if let Some(timestamp_run) = self.timestamp_run_for_row(row_index, row.line_id) {
+            if let Some(timestamp_run) = self
+                .timestamp_run_for_row(row_index, terminal_row_timestamp_index(&self.snapshot, row))
+            {
                 timestamp_runs.push(timestamp_run);
             }
         }
@@ -917,8 +921,8 @@ impl TerminalElement {
         }
     }
 
-    fn timestamp_run_for_row(&self, row_index: usize, line_id: u64) -> Option<BatchedTextRun> {
-        let label = self.row_timestamps.as_ref()?.get(&line_id)?.label.clone();
+    fn timestamp_run_for_row(&self, row_index: usize, index: u64) -> Option<BatchedTextRun> {
+        let label = self.row_timestamps.as_ref()?.get(index)?.label.clone();
         Some(BatchedTextRun {
             row: row_index,
             col: 0,

--- a/crates/oxideterm-gpui-terminal/src/terminal_view/element.rs
+++ b/crates/oxideterm-gpui-terminal/src/terminal_view/element.rs
@@ -865,8 +865,8 @@ impl TerminalElement {
                     &mut cursor,
                 );
             }
-            if let Some(timestamp_run) = self
-                .timestamp_run_for_row(row_index, terminal_row_timestamp_index(&self.snapshot, row))
+            if let Some(timestamp_run) =
+                self.timestamp_run_for_row(row_index, terminal_row_timestamp_identity(row))
             {
                 timestamp_runs.push(timestamp_run);
             }

--- a/crates/oxideterm-terminal/src/local/pty.rs
+++ b/crates/oxideterm-terminal/src/local/pty.rs
@@ -1068,8 +1068,8 @@ fn snapshot_row_source<T: EventListener>(
         .any(|cell| cell.flags.contains(Flags::WRAPLINE));
 
     Some(SnapshotRowSource {
-        // The cell allocation follows the row content when Alacritty rotates or swaps row values.
-        source_id: terminal_cells.as_ptr() as usize,
+        // Emulator-owned identity survives scrolling and cannot alias recycled cell storage.
+        source_id: terminal_row.identity(),
         populated_cols,
         wrapped,
     })


### PR DESCRIPTION
## 问题与修复

时间戳需要跟随同一条终端内容，在滚动、回滚缓冲触顶及局部删行后保持对应关系。视口分配的 `line_id` 和窗口相对行号都不足以承担这个身份；用相邻视口的行位移推算淘汰，也会漏掉批量输出或误判局部滚动。

本次改为使用终端内核拥有的行身份：滚动及行交换保留身份，行存储清空复用时分配新身份。快照和时间戳渲染使用同一身份，不再推算淘汰基数。时间戳仍是视觉元数据，不进入终端文本、复制内容或搜索索引。

同步将内核写死行结构大小的交换实现改为完整行交换，并按缓存条目数量批量修剪时间戳，避免不同终端之间的身份编号间隔影响保留范围。

## 验证

- 使用真实终端解析器新增回归：触顶后单批输出超过一屏、重复内容、整页跳转、返回历史行，以及 ANSI 局部删行。前两条回归在原实现失败，修复后通过。
- `cargo test -p oxideterm-gpui-terminal --lib`：180 通过。
- `cargo test -p alacritty_terminal --lib`：138 通过。
- `cargo test -p oxideterm-terminal --lib`：151 通过。
- 应用 `cargo check`、Rust 1.94.1 格式检查及 `git diff --check` 通过。
- 同环境 `terminal_stream/parse_5000_lines` 基准：修复前约 1.861 ms，修复后约 1.873 ms；Criterion 未检测到显著性能变化（p = 0.67）。

原版本有作者提供的 Windows 11 真机验证；新增修改尚未单独进行 Windows GUI 实机验收，以新一轮 CI 的平台检查结果为准。
